### PR TITLE
Fix issue proofing a data block (leaf) contained in another Buffer

### DIFF
--- a/proof.js
+++ b/proof.js
@@ -11,7 +11,7 @@ function treeWidth (n, h) {
 
 function makeProof (tree, leaf) {
   var index = tree.findIndex(function (node) {
-    return (node instanceof Uint8Array ? Buffer.from(node) : node).equals(leaf)
+    return (!Buffer.isBuffer(node) ? Buffer.from(node) : node).equals(leaf)
   })
 
   // does the leaf node even exist [in the tree]?
@@ -71,7 +71,7 @@ function verify (proof, digestFn) {
     hash = digestFn(data)
   }
 
-  return (hash instanceof Uint8Array ? Buffer.from(hash) : hash).equals(root)
+  return (!Buffer.isBuffer(hash) ? Buffer.from(hash) : hash).equals(root)
 }
 
 module.exports = makeProof

--- a/proof.js
+++ b/proof.js
@@ -10,7 +10,9 @@ function treeWidth (n, h) {
 }
 
 function makeProof (tree, leaf) {
-  var index = tree.indexOf(leaf)
+  var index = tree.findIndex(function (node) {
+    return (node instanceof Uint8Array ? Buffer.from(node) : node).equals(leaf)
+  })
 
   // does the leaf node even exist [in the tree]?
   if (index === -1) return null
@@ -69,7 +71,7 @@ function verify (proof, digestFn) {
     hash = digestFn(data)
   }
 
-  return hash.equals(root)
+  return (hash instanceof Uint8Array ? Buffer.from(hash) : hash).equals(root)
 }
 
 module.exports = makeProof

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ tape('throws on bad types', function (t) {
   t.end()
 })
 
-tape('generation, for each fixture', function (t) {
+tape('generation, for each fixture (both internal nodes and leaves are Buffer)', function (t) {
   t.plan(fixtures.length * 2)
 
   fixtures.forEach(function (f) {
@@ -21,13 +21,61 @@ tape('generation, for each fixture', function (t) {
       return crypto.createHash(f.hash).update(x).digest()
     }
 
-    var values = f.values.map(function (x) { return Buffer.from(x, 'hex') })
-    var tree = merkle(values, digest).map(function (x) { return x.toString('hex') })
-    var root = fastRoot(values, digest).toString('hex')
+    var bufValues = f.values.map(function (x) { return Buffer.from(x, 'hex') })
+    var tree = merkle(bufValues, digest).map(function (x) { return x.toString('hex') })
+    var root = fastRoot(bufValues, digest).toString('hex')
 
     t.same(tree, f.tree, 'matches the tree')
-    t.equal(root, froot, 'fastRoot returns the tree root' + froot)
+    t.equal(root, froot, 'fastRoot returns the tree root ' + root)
   })
 
   t.end()
 })
+
+if (nodeVerMajor() >= 8) {
+  tape('generation, for each fixture (both internal nodes and leaves are Uint8Array)', function (t) {
+    t.plan(fixtures.length * 2)
+
+    fixtures.forEach(function (f) {
+      var froot = f.tree[f.tree.length - 1]
+
+      function digest (x) {
+        return new Uint8Array(crypto.createHash(f.hash).update(x).digest())
+      }
+
+      var arrValues = f.values.map(function (x) { return new Uint8Array(Buffer.from(x, 'hex')) })
+      var tree = merkle(arrValues, digest).map(function (x) { return Buffer.from(x).toString('hex') })
+      var root = Buffer.from(fastRoot(arrValues, digest)).toString('hex')
+
+      t.same(tree, f.tree, 'matches the tree')
+      t.equal(root, froot, 'fastRoot returns the tree root ' + root)
+    })
+
+    t.end()
+  })
+
+  tape('generation, for each fixture (internal nodes are Buffer and leaves are Uint8Array)', function (t) {
+    t.plan(fixtures.length * 2)
+
+    fixtures.forEach(function (f) {
+      var froot = f.tree[f.tree.length - 1]
+      function digest (x) {
+        return crypto.createHash(f.hash).update(x).digest()
+      }
+
+      var arrValues = f.values.map(function (x) { return new Uint8Array(Buffer.from(x, 'hex')) })
+      var tree = merkle(arrValues, digest).map(function (x) { return (x instanceof Uint8Array ? Buffer.from(x) : x).toString('hex') })
+      var mixRoot = fastRoot(arrValues, digest)
+      var root = (tree.length === 1 ? Buffer.from(mixRoot) : mixRoot).toString('hex')
+
+      t.same(tree, f.tree, 'matches the tree')
+      t.equal(root, froot, 'fastRoot returns the tree root ' + root)
+    })
+
+    t.end()
+  })
+}
+
+function nodeVerMajor () {
+  return parseInt(process.version.match(/^v?(\d+)\./)[1])
+}

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ if (nodeVerMajor() >= 8) {
       }
 
       var arrValues = f.values.map(function (x) { return new Uint8Array(Buffer.from(x, 'hex')) })
-      var tree = merkle(arrValues, digest).map(function (x) { return (x instanceof Uint8Array ? Buffer.from(x) : x).toString('hex') })
+      var tree = merkle(arrValues, digest).map(function (x) { return (!Buffer.isBuffer(x) ? Buffer.from(x) : x).toString('hex') })
       var mixRoot = fastRoot(arrValues, digest)
       var root = (tree.length === 1 ? Buffer.from(mixRoot) : mixRoot).toString('hex')
 

--- a/test/proof.js
+++ b/test/proof.js
@@ -4,48 +4,185 @@ var merkle = require('../')
 var merkleProof = require('../proof')
 var tape = require('tape')
 
-tape('proofs, for each fixture', function (t) {
+tape('proofs, for each fixture (both internal nodes and leaves are Buffer)', function (t) {
   fixtures.forEach(function (f) {
     function digest (x) {
       return crypto.createHash(f.hash).update(x).digest()
     }
 
-    f.values.forEach(function (v) {
-      var proof = merkleProof(f.tree, v)
-      t.same(proof, f.proofs[v])
+    var bufTree = f.tree.map(function (n) { return Buffer.from(n, 'hex') })
 
-      // map to Buffers for verify
-      proof = proof.map(function (x) { return x && Buffer.from(x, 'hex') })
-      t.equal(merkleProof.verify(proof, digest), true, 'is verifiable')
+    f.values.forEach(function (v) {
+      var bufValue = Buffer.from(v, 'hex')
+      var bufProof = merkleProof(bufTree, bufValue)
+
+      if (bufProof !== null) {
+        var proof = bufProof.map(function (p) { return p && p.toString('hex') })
+        t.same(proof, f.proofs[v])
+
+        // map to Buffers for verify
+        t.equal(merkleProof.verify(bufProof, digest), true, 'is verifiable')
+      } else {
+        t.fail('Node not found in tree')
+      }
     })
   })
 
   t.end()
 })
 
-tape('various node count proofs', function (t) {
+if (nodeVerMajor() >= 8) {
+  tape('proofs, for each fixture (both internal nodes and leaves are Uint8Array)', function (t) {
+    fixtures.forEach(function (f) {
+      function digest (x) {
+        return new Uint8Array(crypto.createHash(f.hash).update(x).digest())
+      }
+
+      var arrTree = f.tree.map(function (n) { return new Uint8Array(Buffer.from(n, 'hex')) })
+
+      f.values.forEach(function (v) {
+        var arrValue = new Uint8Array(Buffer.from(v, 'hex'))
+        var arrProof = merkleProof(arrTree, arrValue)
+
+        if (arrProof !== null) {
+          var proof = arrProof.map(function (p) { return p && Buffer.from(p).toString('hex') })
+          t.same(proof, f.proofs[v])
+
+          // map to Buffers for verify
+          t.equal(merkleProof.verify(arrProof, digest), true, 'is verifiable')
+        } else {
+          t.fail('Node not found in tree')
+        }
+      })
+    })
+
+    t.end()
+  })
+
+  tape('proofs, for each fixture (internal nodes are Buffer and leaves are Uint8Array)', function (t) {
+    fixtures.forEach(function (f) {
+      function digest (x) {
+        return crypto.createHash(f.hash).update(x).digest()
+      }
+
+      var numValues = f.values.length
+      var mixTree = f.tree.map(function (n, i) { var buf = Buffer.from(n, 'hex'); return i < numValues ? new Uint8Array(buf) : buf })
+
+      f.values.forEach(function (v) {
+        var arrValue = new Uint8Array(Buffer.from(v, 'hex'))
+        var mixProof = merkleProof(mixTree, arrValue)
+
+        if (mixProof !== null) {
+          var proof = mixProof.map(function (p) { return p && (p instanceof Uint8Array ? Buffer.from(p) : p).toString('hex') })
+          t.same(proof, f.proofs[v])
+
+          // map to Buffers for verify
+          t.equal(merkleProof.verify(mixProof, digest), true, 'is verifiable')
+        } else {
+          t.fail('Node not found in tree')
+        }
+      })
+    })
+
+    t.end()
+  })
+}
+
+tape('various node count proofs (both internal nodes and leaves are Buffer)', function (t) {
   function digest (x) {
     return crypto.createHash('sha1').update(x).digest()
   }
 
   var maxNodes = 200
-  var leaves = []
+  var bufLeaves = []
   for (var i = 0; i < maxNodes; ++i) {
     var b = Buffer.alloc(32)
     b.writeUInt32LE(i)
-    leaves.push(b)
+    bufLeaves.push(b)
   }
 
   for (var k = 0; k < maxNodes; ++k) {
-    var bag = leaves.slice(0, k)
-    var tree = merkle(bag, digest)
+    var bufBag = bufLeaves.slice(0, k)
+    var bufTree = merkle(bufBag, digest)
 
-    bag.forEach(function (v) {
-      var proof = merkleProof(tree, v)
+    bufBag.forEach(function (v) {
+      var bufProof = merkleProof(bufTree, v)
 
-      t.equal(merkleProof.verify(proof, digest), true, 'is verifiable')
+      if (bufProof !== null) {
+        t.equal(merkleProof.verify(bufProof, digest), true, 'is verifiable')
+      } else {
+        t.fail('Node not found in tree')
+      }
     })
   }
 
   t.end()
 })
+
+if (nodeVerMajor() >= 8) {
+  tape('various node count proofs (both internal nodes and leaves are Uint8Array)', function (t) {
+    function digest (x) {
+      return new Uint8Array(crypto.createHash('sha1').update(x).digest())
+    }
+
+    var maxNodes = 200
+    var arrLeaves = []
+    for (var i = 0; i < maxNodes; ++i) {
+      var b = Buffer.alloc(32)
+      b.writeUInt32LE(i)
+      arrLeaves.push(new Uint8Array(b))
+    }
+
+    for (var k = 0; k < maxNodes; ++k) {
+      var arrBag = arrLeaves.slice(0, k)
+      var arrTree = merkle(arrBag, digest)
+
+      arrBag.forEach(function (v) {
+        var arrProof = merkleProof(arrTree, v)
+
+        if (arrProof !== null) {
+          t.equal(merkleProof.verify(arrProof, digest), true, 'is verifiable')
+        } else {
+          t.fail('Node not found in tree')
+        }
+      })
+    }
+
+    t.end()
+  })
+
+  tape('various node count proofs (internal nodes are Buffer and leaves are Uint8Array)', function (t) {
+    function digest (x) {
+      return crypto.createHash('sha1').update(x).digest()
+    }
+
+    var maxNodes = 200
+    var arrLeaves = []
+    for (var i = 0; i < maxNodes; ++i) {
+      var b = Buffer.alloc(32)
+      b.writeUInt32LE(i)
+      arrLeaves.push(new Uint8Array(b))
+    }
+
+    for (var k = 0; k < maxNodes; ++k) {
+      var arrBag = arrLeaves.slice(0, k)
+      var mixTree = merkle(arrBag, digest)
+
+      arrBag.forEach(function (v) {
+        var mixProof = merkleProof(mixTree, v)
+
+        if (mixProof !== null) {
+          t.equal(merkleProof.verify(mixProof, digest), true, 'is verifiable')
+        } else {
+          t.fail('Node not found in tree')
+        }
+      })
+    }
+
+    t.end()
+  })
+}
+
+function nodeVerMajor () {
+  return parseInt(process.version.match(/^v?(\d+)\./)[1])
+}

--- a/test/proof.js
+++ b/test/proof.js
@@ -73,7 +73,7 @@ if (nodeVerMajor() >= 8) {
         var mixProof = merkleProof(mixTree, arrValue)
 
         if (mixProof !== null) {
-          var proof = mixProof.map(function (p) { return p && (p instanceof Uint8Array ? Buffer.from(p) : p).toString('hex') })
+          var proof = mixProof.map(function (p) { return p && (!Buffer.isBuffer(p) ? Buffer.from(p) : p).toString('hex') })
           t.same(proof, f.proofs[v])
 
           // map to Buffers for verify


### PR DESCRIPTION
This is a fix for issue #8 where the data block (leaf) to be proofed is in a Buffer different from the one used when building the tree. The changes also allow for internal nodes and leaves to be either a Buffer or a Uint8Array instance (though Uint8Array only works for Node.js version 8 and above).